### PR TITLE
Add a podspec for JTTableViewGestureRecognizer

### DIFF
--- a/JTTableViewGestureRecognizer.podspec
+++ b/JTTableViewGestureRecognizer.podspec
@@ -1,0 +1,12 @@
+Pod::Spec.new do |s|
+  s.name         = "JTTableViewGestureRecognizer"
+  s.version      = "0.0.1"
+  s.summary      = "An iOS objective-C library template to recreate the gesture based interaction found from Clear for iPhone app."
+  s.homepage     = "https://github.com/jamztang/JTGestureBasedTableViewDemo"
+  s.license      = { :type => "MIT", :file => "JTGestureBasedTableView/LICENSE" }
+  s.author       = "James Tang"
+  s.platform     = :ios, "6.1"
+  s.source       = { :git => "https://github.com/jamztang/JTGestureBasedTableViewDemo.git", :tag => "#{s.version}" }
+  s.source_files = "JTGestureBasedTableView/JTTableViewGestureRecognizer.{h,m}"
+  s.requires_arc = true
+end


### PR DESCRIPTION
Just a podspec to use `JTTableViewGestureRecognizer` more easily via CocoaPods.

``` ruby
pod 'JTTableViewGestureRecognizer', :git => "https://github.com/jamztang/JTGestureBasedTableViewDemo.git"
```

Please add a tag which the podspec requires. Thanks for creating this demo!
